### PR TITLE
bugfix: Consent Information does not match Google SDK spec

### DIFF
--- a/addon/model/ConsentInformation.gd
+++ b/addon/model/ConsentInformation.gd
@@ -4,9 +4,11 @@
 
 class_name ConsentInformation extends RefCounted
 
+
+# https://developers.google.com/admob/android/reference/privacy/com/google/android/ump/ConsentInformation.ConsentStatus
 enum ConsentStatus {
 	UNKNOWN = 0,
-	REQUIRED = 1,
-	NOT_REQUIRED = 2,
+	NOT_REQUIRED = 1,
+	REQUIRED = 2,
 	OBTAINED = 3
 }


### PR DESCRIPTION
Hello @cengiz-pz ,

I was testing your plugin out with my android mobile game, and I found that it kept coming back with consent status as required.
When I checked google's Mobile SDK online, I found the values don't match.

https://developers.google.com/admob/android/reference/privacy/com/google/android/ump/ConsentInformation.ConsentStatus

I was able to test this one locally, as it did not require a full rebuild of the plugin, and it seemed to work well with my mobile app.