### PR TITLE
Switch iOS build to dynamic libraries and xcframeworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # © 2024-present https://github.com/cengiz-pz
 #
-
+.DS_Store
 demo/addons
 demo/android
 demo/ios

--- a/ios/SConstruct
+++ b/ios/SConstruct
@@ -193,10 +193,25 @@ sources.append(Glob(f'{plugin_name}/**/*.cpp'))
 sources.append(Glob(f'{plugin_name}/**/*.mm'))
 sources.append(Glob(f'{plugin_name}/**/*.m'))
 
-# lib<plugin>.<arch>-<simulator|iphone>.<release|debug|release_debug>.a
+# lib<plugin>.<arch>-<simulator|iphone>.<release|debug|release_debug>.dylib
 library_platform = env["arch"] + "-" + ("simulator" if env["simulator"] else "ios")
-library_name = env['target_name'] + "." + library_platform + "." + env['target'] + ".a"
-library = env.StaticLibrary(target=env['target_path'] + library_name, source=sources)
+library_name = env['target_name'] + "." + library_platform + "." + env['target'] + ".dylib"
+
+# Set install_name for dylib
+install_name = "@rpath/" + env['target_name'] + ".framework/" + env['target_name']
+env.Append(LINKFLAGS=['-dynamiclib', '-install_name', install_name])
+
+# Allow undefined symbols (they will be provided by Godot at runtime)
+env.Append(LINKFLAGS=['-undefined', 'dynamic_lookup'])
+
+# Link against required frameworks
+env.Append(LINKFLAGS=[
+	'-framework', 'Foundation',
+	'-framework', 'UIKit',
+	'-framework', 'CoreGraphics'
+])
+
+library = env.SharedLibrary(target=env['target_path'] + library_name, source=sources)
 
 Default(library)
 

--- a/ios/config/AdmobPlugin.gdip
+++ b/ios/config/AdmobPlugin.gdip
@@ -4,7 +4,9 @@
 
 [config]
 name="@pluginName@"
-binary="@pluginName@.a"
+binary_type="xcframework"
+binary="@pluginName@.release.xcframework"
+binary_debug="@pluginName@.debug.xcframework"
 
 initialization="@iosInitializationMethod@"
 deinitialization="@iosDeinitializationMethod@"
@@ -13,7 +15,7 @@ use_swift_runtime=true
 
 [dependencies]
 linked=[]
-embedded=[]
+embedded=[@pluginName@.release.xcframework, @pluginName@.debug.xcframework]
 system=[]
 
 capabilities=[]


### PR DESCRIPTION
Updated the iOS build process to generate dynamic libraries (.dylib) instead of static libraries (.a), and package them as xcframeworks for both release and debug builds. Modified SConstruct to build shared libraries with appropriate linker flags and framework dependencies. Updated AdmobPlugin.gdip config to reference xcframeworks and embed them. Refactored build.sh to support dynamic library creation, xcframework packaging, and updated artifact copying accordingly. Added .DS_Store to .gitignore.