### PR TITLE
Added a final fallback to node search during export

### DIFF
--- a/addon/Admob.gd
+++ b/addon/Admob.gd
@@ -108,6 +108,11 @@ const MAXIMUM_CACHE_SIZE: int = 1000
 ## If not set to disabled, then specifies the direction towards which the banner ad will collapse.
 @export var banner_collapsible_position: LoadAdRequest.CollapsiblePosition = LoadAdRequest.CollapsiblePosition.DISABLED: set = set_banner_collapsible_position
 
+## When enabled, the banner ad will be positioned within the device’s safe area, leaving space at the top or bottom to avoid UI elements
+## such as notches, rounded corners, and home indicator bars. When disabled, the banner will be anchored directly to the top or bottom edge
+## of the screen, ignoring safe area insets.
+@export var banner_anchor_to_safe_area: bool = false
+
 
 @export_group("App Open")
 ## Specifies whether app open ad will be displayed when users return the app to the foreground state.
@@ -558,7 +563,8 @@ func create_banner_ad_request() -> LoadAdRequest:
 			.set_ad_unit_id(_banner_id)
 			.set_ad_position(banner_position)
 			.set_ad_size(banner_size)
-			.set_collapsible_position(banner_collapsible_position))
+			.set_collapsible_position(banner_collapsible_position)
+			.set_anchor_to_safe_area(banner_anchor_to_safe_area))
 
 
 func load_banner_ad(a_request: LoadAdRequest = null) -> void:

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ minSdk = "24"
 buildTools = "35.0.0"
 appcompat = "1.7.1"
 lifecycle = "2.8.3"
-playads = "24.8.0"
+playads = "24.9.0"
 
 [libraries]
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -206,7 +206,7 @@ layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
 script = ExtResource("4_fos0i")
-max_ad_height = 300
+max_ad_height = 200
 admob_path = NodePath("../../../../../../../../Admob")
 auto_load = true
 


### PR DESCRIPTION
Previously:

- Search currently-edited scene for Admob node
- If not found, search the configured main scene in the Project Settings
- Load Admob settings if an Admob node was found, give up otherwise

Now:

- Search currently-edited scene for Admob node
- If not found, search the configured main scene in the Project Settings
- If not found, search every project directory recursively and every project scene
- Load Admob settings if an Admob node was found, give up otherwise, because that would mean that there is no Admob node inside the project