### PR TITLE
chore: update actions to Node 24 versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.md linguist-detectable=true

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -6,7 +6,8 @@ name: Android CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'common/config/**'
       - 'common/**/*.gradle.kts'
@@ -21,7 +22,7 @@ jobs:
 
     steps:
       # -- Checkout ------------------------------------------------------------
-      - name: Checkout repository
+      - name: Checkout 
         uses: actions/checkout@v6
 
       # -- Node ----------------------------------------------------------------
@@ -38,7 +39,7 @@ jobs:
 
       # -- Android SDK ---------------------------------------------------------
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       # -- Gradle --------------------------------------------------------------
       - name: Make Gradle wrapper executable
@@ -65,7 +66,7 @@ jobs:
       # the step above fails (always: true keeps this step active on failure).
       - name: Upload Android test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: android-test-results
           path: android/build/test-results/testDebugUnitTest/

--- a/.github/workflows/android-style.yml
+++ b/.github/workflows/android-style.yml
@@ -6,7 +6,8 @@ name: Android Code Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'android/src/**/*.java'
       - 'android/src/**/*.kt'
@@ -17,7 +18,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
 
       - name: Set up Java
         uses: actions/setup-java@v5

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -6,7 +6,8 @@ name: Auto Label Issues
 
 on:
   issues:
-    types: [opened]
+    types:
+        - opened
 
 jobs:
   triage:
@@ -16,13 +17,13 @@ jobs:
       contents: read # Required to read the labels.yml file
 
     steps:
-      - name: Checkout Repository
+      - name: Checkout 
         uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: 3.x
 
       - name: Install Dependencies
         run: pip install pyyaml google-genai requests

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 
@@ -47,10 +47,10 @@ jobs:
         run: zensical build --clean --config-file docs/zensical.toml
 
       - name: Upload Pages
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ${{ github.workspace }}/docs/site
 
       - name: Deploy Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/gdscript-style.yml
+++ b/.github/workflows/gdscript-style.yml
@@ -6,7 +6,8 @@ name: GDScript Code Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'addon/src/**/*.gd'
       - 'demo/**/*.gd'
@@ -16,7 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
 
       - name: Install gdtoolkit
         run: |

--- a/.github/workflows/gradle-kts-style.yml
+++ b/.github/workflows/gradle-kts-style.yml
@@ -6,7 +6,8 @@ name: Gradle Kotlin DSL Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - '**/*.gradle.kts'
 
@@ -15,7 +16,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
 
       - name: Install Node
         uses: ./.github/actions/install-node

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -6,7 +6,8 @@ name: iOS CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: 
+      - main
     paths:
       - 'common/config/**'
       - 'common/**/*.gradle.kts'
@@ -24,7 +25,7 @@ jobs:
 
     steps:
       # -- Checkout ------------------------------------------------------------
-      - name: Checkout repository
+      - name: Checkout 
         uses: actions/checkout@v6
 
       # -- Node ----------------------------------------------------------------
@@ -69,7 +70,7 @@ jobs:
 
       - name: Upload iOS test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ios-test-results
           path: ios/build/TestResults/

--- a/.github/workflows/ios-style.yml
+++ b/.github/workflows/ios-style.yml
@@ -6,7 +6,8 @@ name: iOS Code Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'ios/src/**/*.m'
       - 'ios/src/**/*.mm'
@@ -18,7 +19,8 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
 
       - name: Install SwiftLint
         run: brew install swiftlint

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -6,7 +6,8 @@ name: Sync Labels
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - '.github/config/labels.yml'
 
@@ -18,10 +19,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github/config/labels.yml
 
+      - name: Label Sync 
       - uses: EndBug/label-sync@v2
         with:
           config-file: .github/config/labels.yml

--- a/.github/workflows/properties-style.yml
+++ b/.github/workflows/properties-style.yml
@@ -6,7 +6,8 @@ name: Properties File Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'common/config/*.properties'
       - 'ios/config/*.properties'
@@ -16,7 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
 
       - name: Install editorconfig-checker
         uses: ./.github/actions/install-ec

--- a/.github/workflows/release-on-milestone.yml
+++ b/.github/workflows/release-on-milestone.yml
@@ -6,7 +6,8 @@ name: Draft Release on Milestone Close
 
 on:
   milestone:
-    types: [closed]
+    types:
+      - closed
   workflow_dispatch:
     inputs:
       version:
@@ -29,7 +30,7 @@ jobs:
 
     steps:
       # -- Checkout ------------------------------------------------------------
-      - name: Checkout repository
+      - name: Checkout 
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -82,7 +83,7 @@ jobs:
 
       # -- Prepare for Android build -------------------------------------------
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       # -- Create archives -----------------------------------------------------
       - name: Run createArchives

--- a/.github/workflows/script-style.yml
+++ b/.github/workflows/script-style.yml
@@ -6,7 +6,8 @@ name: Script Code Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'script/**/*.sh'
       - 'script/**/*.rb'
@@ -16,7 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
 
       - name: Install Node
         uses: ./.github/actions/install-node


### PR DESCRIPTION
this fixes Node.js actions are deprecation by moving all actions to Node.js 24 compatible version